### PR TITLE
Update eZ-Publish-extensions.html quick links to manuals bugfixes

### DIFF
--- a/Extensions.html
+++ b/Extensions.html
@@ -107,8 +107,8 @@
 <div id="quicklinks">
 <h4>eZ Publish</h4>
 <ul>
-<li><a href="eZ-Publish/Technical-manual/5.html">Technical manual (v5.x)</a></li>
-<li><a href="eZ-Publish/User-manual/5.html">User manual (v5.x)</a></li>
+<li><a href="eZ-Publish/Technical-manual/5.x.html">Technical manual (v5.x)</a></li>
+<li><a href="eZ-Publish/User-manual/5.x.html">User manual (v5.x)</a></li>
 <li><a href="eZ-Publish/Upgrading.html">Upgrading manual</a></li>
 <li><a href="Extensions/eZ-Publish-extensions.html">Extensions manuals</a></li>
 </ul>

--- a/Extensions/eZ-Publish-extensions.html
+++ b/Extensions/eZ-Publish-extensions.html
@@ -113,8 +113,8 @@
 <div id="quicklinks">
 <h4>eZ Publish</h4>
 <ul>
-<li><a href="../eZ-Publish/Technical-manual/5.html">Technical manual (v5.x)</a></li>
-<li><a href="../eZ-Publish/User-manual/5.html">User manual (v5.x)</a></li>
+<li><a href="../eZ-Publish/Technical-manual/5.x.html">Technical manual (v5.x)</a></li>
+<li><a href="../eZ-Publish/User-manual/5.x.html">User manual (v5.x)</a></li>
 <li><a href="../eZ-Publish/Upgrading.html">Upgrading manual</a></li>
 <li><a href="../Extensions/eZ-Publish-extensions.html">Extensions manuals</a></li></ul>
 


### PR DESCRIPTION
Minor change: nav link bugfixes

Was just browsing the documentation website and saw that the quick link navigation was broken in one specific place.

Cheers,
7x